### PR TITLE
Added double quotes to RedShift columns for UNLOAD command

### DIFF
--- a/redshift/config.go
+++ b/redshift/config.go
@@ -70,7 +70,7 @@ func (s *RedshiftSource) SelectClause() string {
 		if i > 0 {
 			columns.WriteString(",")
 		}
-		columns.WriteString(s.Schema.Columns[i].Name)
+		columns.WriteString("\""+s.Schema.Columns[i].Name+"\"")
 	}
 	if !s.isPartitioned() {
 		return fmt.Sprintf("SELECT %s FROM %s %s", columns.String(), s.Table, s.where())


### PR DESCRIPTION
Fixes the situation when one of your columns is named as reserved word.
I have a column "in". And when I try to use a script I get: error unloading: pq: syntax error at or near "in"

That's why we need to add double quotes to all the columns for correct UNLOAD operation